### PR TITLE
Added note about key store env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,19 @@ export OPEN311_GUEST_USERNAME="Z"
 export OPEN311_GUEST_PASSWORD="A"
 export OPEN311_ENCRYPT_KEY="B"
 export OPEN311_BASE_URL="C"
+export OPEN311_KEY_STORE_PW="D"
+export OPEN311_KEY_STORE_FILE="E"
 ```
 
 then build using our build script which wraps the standard `flutter` executable:
 
 ```bash
 ./flutter_it.sh run
+```
+
+Note: Without the KEY\_STORE env vars set, gradle may exit with a vague error:
+```
+* What went wrong:
+A problem occurred evaluating project ':app'.
+> path may not be null or empty string. path='null'
 ```


### PR DESCRIPTION
The prebuild.sh will skip generating key.properties but that caused my gradle build to fail. I added the extra notes about the env vars, but I'm not sure if that's a fix or a bandaid. Should the build be able to run without the key stuff?