### PR TITLE
Updated geocoder library version 

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
 
   location: ^1.4.1
 
-  geocoder: 0.1.2
+  geocoder: 0.2.1
 
   flutter_map: ^0.7.1
 


### PR DESCRIPTION
I was seeing a strange crash on Android where app would exit after selecting a city. Updating the geocoder library fixed it for me. Any chance to verify on IOS?